### PR TITLE
fix(client-main): Collision between tank objects and vehicle

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -269,6 +269,7 @@ RegisterNetEvent('qb-diving:client:UseGear', function(bool)
                 Wait(0)
             end
             local TankObject = CreateObject(tankModel, 1.0, 1.0, 1.0, 1, 1, 0)
+            SetEntityCollision(TankObject, false, false)
             local bone1 = GetPedBoneIndex(ped, 24818)
             AttachEntityToEntity(TankObject, ped, bone1, -0.25, -0.25, 0.0, 180.0, 90.0, 0.0, 1, 1, 0, 0, 2, 1)
             currentGear.tank = TankObject
@@ -277,6 +278,7 @@ RegisterNetEvent('qb-diving:client:UseGear', function(bool)
                 Wait(0)
             end
             local MaskObject = CreateObject(maskModel, 1.0, 1.0, 1.0, 1, 1, 0)
+            SetEntityCollision(MaskObject, false, false)
             local bone2 = GetPedBoneIndex(ped, 12844)
             AttachEntityToEntity(MaskObject, ped, bone2, 0.0, 0.0, 0.0, 180.0, 90.0, 0.0, 1, 1, 0, 0, 2, 1)
             currentGear.mask = MaskObject


### PR DESCRIPTION
**Describe Pull request**
Entering a vehicle with oxygen tank on can cause the vehicle to collide with the oxygen tank objects (of which there are two).
Thanks to an issue opened up by @[omar-othmann](https://github.com/omar-othmann), we were able to test and determine a fix for this.
The only testing that has not been conducted is testing based on migrating object IDs, but based on the fact that the object remains with the user continiously, it shouldn't have an effect.

If your PR is to fix an issue mention that issue here
#38 

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? Yes (Be honest)
- Does your code fit the style guidelines? Yes
- Does your PR fit the contribution guidelines? Yes
