### PR TITLE
Add  Coral prop/outline and fix Delete Object

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -7,6 +7,7 @@ local iswearingsuit = false
 local oxgenlevell = 0
 local Coral = {}
 local CoralProp = `prop_coral_pillar_01`
+local peds = {}
 
 local currentDivingLocation = {
     area = 0,
@@ -212,12 +213,12 @@ local function createSeller()
             Wait(0)
         end
         local currentCoords = vector4(current.coords.x, current.coords.y, current.coords.z - 1, current.coords.w)
-        local ped = CreatePed(0, current.model, currentCoords, false, false)
-        FreezeEntityPosition(ped, true)
-        SetEntityInvincible(ped, true)
-        SetBlockingOfNonTemporaryEvents(ped, true)
+        local peds[i] = CreatePed(0, current.model, currentCoords, false, false)
+        FreezeEntityPosition(peds[i], true)
+        SetEntityInvincible(peds[i], true)
+        SetBlockingOfNonTemporaryEvents(peds[i], true)
         if Config.UseTarget then
-            exports['qb-target']:AddTargetEntity(ped, {
+            exports['qb-target']:AddTargetEntity(peds[i], {
                 options = {
                     {
                         label = Lang:t("info.sell_coral"),

--- a/client/main.lua
+++ b/client/main.lua
@@ -117,7 +117,9 @@ local function setDivingLocation(divingLocation)
     currentDivingLocation.blip.label = labelBlip
     for k, v in pairs(Config.CoralLocations[currentDivingLocation.area].coords.Coral) do
         loadCoral()
-        Coral[k] = CreateObject(CoralProp, v.coords.x, v.coords.y, v.coords.z+0.5, false, false, false)
+        Coral[k] = CreateObject(CoralProp, v.coords.x, v.coords.y, v.coords.z+0.5, false, false, false)	
+        PlaceObjectOnGroundProperly(Coral[k])
+        FreezeEntityPosition(Coral[k], true)
         if Config.UseTarget then
             exports['qb-target']:AddBoxZone('diving_coral_zone_'..k, v.coords, v.length, v.width, {
                 name = 'diving_coral_zone_'..k,

--- a/client/main.lua
+++ b/client/main.lua
@@ -164,12 +164,11 @@ local function setDivingLocation(divingLocation)
         useZ = true,
     })
     local combo_coral = ComboZone:Create({CircleZone}, {name="combo_coral", debugPoly=false})
-    combo_coral:onPlayerInOut(function(isPointInside, point, zone)
+    combo_coral:onPlayerInOut(function(isPointInside)
         if isPointInside then
-            local set = false
             while isPointInside do
                 local coords = GetEntityCoords(PlayerPedId())
-                for k,v in pairs(Coral) do
+                for _,v in pairs(Coral) do
                     local loc = GetEntityCoords(v)
                     if #(loc - coords) < 25 then
                         SetEntityDrawOutline(v, true)
@@ -182,7 +181,7 @@ local function setDivingLocation(divingLocation)
                 Wait(1000)
             end
         else
-            for k,v in pairs(Coral) do
+            for _,v in pairs(Coral) do
                 SetEntityDrawOutline(v, false)
             end
         end

--- a/client/main.lua
+++ b/client/main.lua
@@ -5,6 +5,7 @@ local currentArea = 0
 local inSellerZone = false
 local iswearingsuit = false
 local oxgenlevell = 0
+local Coral = {}
 
 local currentDivingLocation = {
     area = 0,
@@ -21,6 +22,16 @@ local currentGear = {
 }
 
 -- Functions
+
+function loadCoral()	
+    local CoralProp = `prop_coral_pillar_01`
+    RequestModel(CoralProp)
+    while not HasModelLoaded(CoralProp) do
+        RequestModel(CoralProp)
+        Wait(0)
+    end
+end
+
 local function callCops()
     local call = math.random(1, 3)
     local chance = math.random(1, 3)
@@ -33,12 +44,12 @@ end
 local function deleteGear()
 	if currentGear.mask ~= 0 then
         DetachEntity(currentGear.mask, 0, 1)
-        DeleteEntity(currentGear.mask)
+        DeleteObject(currentGear.mask)
 		currentGear.mask = 0
     end
 	if currentGear.tank ~= 0 then
         DetachEntity(currentGear.tank, 0, 1)
-        DeleteEntity(currentGear.tank)
+        DeleteObject(currentGear.tank)
 		currentGear.tank = 0
 	end
 
@@ -69,6 +80,8 @@ local function takeCoral(coral)
         Config.CoralLocations[currentDivingLocation.area].coords.Coral[coral].PickedUp = true
         TriggerServerEvent('qb-diving:server:TakeCoral', currentDivingLocation.area, coral, true)
         ClearPedTasks(ped)
+        SetEntityDrawOutline(Coral[coral], false)
+        DeleteObject(Coral[coral])
         FreezeEntityPosition(ped, false)
     end, function() -- Cancel
         ClearPedTasks(ped)
@@ -77,6 +90,7 @@ local function takeCoral(coral)
 end
 local function setDivingLocation(divingLocation)
     if currentDivingLocation.area ~= 0 then
+        exports['qb-target']:RemoveZone('coral_zone')
         for k in pairs(Config.CoralLocations[currentDivingLocation.area].coords.Coral) do
             if Config.UseTarget then
                 exports['qb-target']:RemoveZone(k)
@@ -102,6 +116,8 @@ local function setDivingLocation(divingLocation)
     EndTextCommandSetBlipName(labelBlip)
     currentDivingLocation.blip.label = labelBlip
     for k, v in pairs(Config.CoralLocations[currentDivingLocation.area].coords.Coral) do
+        loadCoral()
+        Coral[k] = CreateObject(CoralProp, v.coords.x, v.coords.y, v.coords.z+0.5, false, false, false)
         if Config.UseTarget then
             exports['qb-target']:AddBoxZone('diving_coral_zone_'..k, v.coords, v.length, v.width, {
                 name = 'diving_coral_zone_'..k,
@@ -140,6 +156,35 @@ local function setDivingLocation(divingLocation)
             end)
         end
     end
+    local CircleZone = CircleZone:Create(Config.CoralLocations[currentDivingLocation.area].coords.Area, 100.0, {
+        name="coral_zone",
+        debugPoly=false,
+        useZ = true,
+    })
+    local combo_coral = ComboZone:Create({CircleZone}, {name="combo_coral", debugPoly=false})
+    combo_coral:onPlayerInOut(function(isPointInside, point, zone)
+        if isPointInside then
+            local set = false
+            while isPointInside do
+                local coords = GetEntityCoords(PlayerPedId())
+                for k,v in pairs(Coral) do
+                    local loc = GetEntityCoords(v)
+                    if #(loc - coords) < 25 then
+                        SetEntityDrawOutline(v, true)
+                        SetEntityDrawOutlineColor(50, 50, 200, 150)
+                        SetEntityDrawOutlineShader(1)
+                    else
+                        SetEntityDrawOutline(v, false)
+                    end
+                end
+                Wait(1000)
+            end
+        else
+            for k,v in pairs(Coral) do
+                SetEntityDrawOutline(v, false)
+            end
+        end
+    end)
 end
 
 local function sellCoral()

--- a/client/main.lua
+++ b/client/main.lua
@@ -6,6 +6,7 @@ local inSellerZone = false
 local iswearingsuit = false
 local oxgenlevell = 0
 local Coral = {}
+local CoralProp = `prop_coral_pillar_01`
 
 local currentDivingLocation = {
     area = 0,
@@ -23,8 +24,7 @@ local currentGear = {
 
 -- Functions
 
-function loadCoral()	
-    local CoralProp = `prop_coral_pillar_01`
+function loadCoral()
     RequestModel(CoralProp)
     while not HasModelLoaded(CoralProp) do
         RequestModel(CoralProp)
@@ -117,7 +117,7 @@ local function setDivingLocation(divingLocation)
     currentDivingLocation.blip.label = labelBlip
     for k, v in pairs(Config.CoralLocations[currentDivingLocation.area].coords.Coral) do
         loadCoral()
-        Coral[k] = CreateObject(CoralProp, v.coords.x, v.coords.y, v.coords.z+0.5, false, false, false)	
+        Coral[k] = CreateObject(CoralProp, v.coords.x, v.coords.y, v.coords.z+0.5, false, false, false)
         PlaceObjectOnGroundProperly(Coral[k])
         FreezeEntityPosition(Coral[k], true)
         if Config.UseTarget then

--- a/client/main.lua
+++ b/client/main.lua
@@ -213,7 +213,7 @@ local function createSeller()
             Wait(0)
         end
         local currentCoords = vector4(current.coords.x, current.coords.y, current.coords.z - 1, current.coords.w)
-        local peds[i] = CreatePed(0, current.model, currentCoords, false, false)
+        peds[i] = CreatePed(0, current.model, currentCoords, false, false)
         FreezeEntityPosition(peds[i], true)
         SetEntityInvincible(peds[i], true)
         SetBlockingOfNonTemporaryEvents(peds[i], true)


### PR DESCRIPTION
was impossible to find the coral this is a major improvement and it was failing to take the prop off your back. Added coral props and drew an outline on them when within distance. Put distance check loop in a circle zone where the blip spawns so the loop doesnt fire until you are within that zone. 

**Describe Pull request**
First, make sure you've read and are following the contribution guidelines and style guide and your code reflects that.
Write up a clear and concise description of what your pull request adds or fixes and if it's an added feature explain why you think it should be included in the core.

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
