### PR TITLE
Fix sell reward, rework modifier

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -1,7 +1,7 @@
 Config = Config or {}
 Config.UseTarget = GetConvar('UseTarget', 'false') == 'true' -- Use qb-target interactions (don't change this, go to your server.cfg and add `setr UseTarget true` to use this and just that from true to false or the other way around)
 Config.CopsChance = 0.5 -- The chance of the cops getting called when a coral gets picked up, this ranges from 0.0 to 1.0
-Config.oxygenlevel = 200 -- this is oxygen level you can change this numper as you like 
+Config.oxygenlevel = 200 -- this is oxygen level you can change this number as you like 
 Config.CoralLocations = {
     [1] = {
         label = "This is Location 1",
@@ -262,23 +262,26 @@ Config.CoralTypes = {
         price = math.random(50, 70),
     }
 }
-Config.PriceModifiers = {
+
+-- Amount is amount of coral being sold to be plaed in a bonus tier. (eg. sell 5-10 coral, placed in tier 1.)
+-- Bonus is min/max percentage bonus paid for coral sales. (eg. Sell 5 coral with 10% bonus | 1 coral = $100 + $10 bonus.)
+Config.BonusTiers = {
     [1] = {
         minAmount = 5,
         maxAmount = 10,
-        minPercentage = 80,
-        maxPercentage = 85
+        minBonus = 5,
+        maxBonus = 10
     },
     [2] = {
         minAmount = 11,
         maxAmount = 15,
-        minPercentage = 70,
-        maxPercentage = 75
+        minBonus = 10,
+        maxBonus = 15
     },
     [3] = {
         minAmount = 16,
-        minPercentage = 50,
-        maxPercentage = 55
+        minBonus = 15,
+        maxBonus = 20
     }
 }
 Config.SellLocations = {

--- a/server/main.lua
+++ b/server/main.lua
@@ -5,10 +5,12 @@ local availableCoral = {}
 -- Functions
 
 local function getItemPrice(amount, price)
-    for k, v in pairs(Config.PriceModifiers) do
-        local modifier = #Config.PriceModifiers == k and amount >= v.minAmount or amount >= v.minAmount and amount <= v.maxAmount
+    for k, v in pairs(Config.BonusTiers) do
+        local modifier = #Config.BonusTiers == k and amount >= v.minAmount or amount >= v.minAmount and amount <= v.maxAmount
         if modifier then
-            price /= 100 * math.random(v.minPercentage, v.maxPercentage)
+            local percent = math.random(v.minBonus, v.maxBonus) / 100
+            local bonus = price * percent
+            price = price + bonus
             price = math.ceil(price)
         end
     end
@@ -54,7 +56,7 @@ RegisterNetEvent('qb-diving:server:SellCoral', function()
             local price = item.amount * v.price
             local reward = getItemPrice(item.amount, price)
             Player.Functions.RemoveItem(item.name, item.amount)
-            Player.Functions.AddMoney('cash', math.ceil(reward / item.amount), "sold-coral")
+            Player.Functions.AddMoney('cash', reward, "sold-coral")
             TriggerClientEvent('inventory:client:ItemBox', src, QBCore.Shared.Items[item.name], "remove")
         end
     else


### PR DESCRIPTION
As noted in issue #89 selling a large quantity of coral resulted in a $1 reward.

This commit fixes the cash payout, and reworks the old modifier into a bonus system. 

Prior to these changes, the more coral you sold, the less money would be rewarded. 
This changes it to give a bonus percentage that gets higher when selling more coral, giving reward for risking having more illegal items in your pockets.

**Questions (please complete the following information):**
- [x] Have you personally loaded this code into an updated qbcore project and checked all it's functionality? 
- [x] Does your code fit the style guidelines? 
- [x] Does your PR fit the contribution guidelines? 
