### PR TITLE
Patch 2

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -306,6 +306,7 @@ RegisterNetEvent('qb-diving:client:UseGear', function()
                         AttachEntityToEntity(currentGear.mask, ped, bone2, 0.0, 0.0, 0.0, 180.0, 90.0, 0.0, 1, 1, 0, 0, 2
                             , 1)
                         SetEnableScuba(ped, true)
+			TriggerServerEvent('qb-diving:server:ScubaItem', true)
                         SetPedMaxTimeUnderwater(ped, 2000.00)
                         currentGear.enabled = true
                         ClearPedTasks(ped)
@@ -352,10 +353,15 @@ RegisterNetEvent('qb-diving:client:UseGear', function()
         else
             QBCore.Functions.Notify(Lang:t("error.need_otube"), 'error')
         end
-    elseif iswearingsuit == true then
+    end
+end)
+
+RegisterNetEvent('qb-diving:client:UseGearOff', function()
+    if iswearingsuit == true then
         gearAnim()
         QBCore.Functions.Progressbar("remove_gear", Lang:t("info.pullout_suit"), 5000, false, true, {}, {}, {}, {},
             function() -- Done
+                TriggerServerEvent('qb-diving:server:ScubaItem', false)
                 SetEnableScuba(ped, false)
                 SetPedMaxTimeUnderwater(ped, 50.00)
                 currentGear.enabled = false

--- a/server/main.lua
+++ b/server/main.lua
@@ -119,6 +119,12 @@ RegisterNetEvent('qb-diving:server:ScubaItem', function(status)
     end
  end)
 
+-- Commands
+
+QBCore.Commands.Add('removegear', "Remove the fivingplongé", {}, true, function(source, args)
+    TriggerClientEvent("qb-diving:client:UseGearOff", source)
+end)
+
 
 -- Callbacks
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -107,6 +107,19 @@ RegisterNetEvent('qb-diving:server:removeItemAfterFill', function()
    TriggerClientEvent('inventory:client:ItemBox', src, QBCore.Shared.Items["diving_fill"], "remove")
 end)
 
+RegisterNetEvent('qb-diving:server:ScubaItem', function(status)
+    local src = source
+    local Player = QBCore.Functions.GetPlayer(src)
+    if status then
+        Player.Functions.RemoveItem("diving_gear", 1)
+        TriggerClientEvent('inventory:client:ItemBox', src, QBCore.Shared.Items["diving_gear"], "remove")
+    else
+        Player.Functions.AddItem("diving_gear", 1)
+        TriggerClientEvent('inventory:client:ItemBox', src, QBCore.Shared.Items["diving_gear"], "remove")
+    end
+ end)
+
+
 -- Callbacks
 
 QBCore.Functions.CreateCallback('qb-diving:server:GetDivingConfig', function(_, cb)


### PR DESCRIPTION
**Describe Pull request**
When you used the item, you always had it in your inventory, and you could give it to another player. This was done by simply removing the item upon use and restoring it with the 'removegear' command.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
